### PR TITLE
docs: add a readme for transforms example

### DIFF
--- a/examples/transforms/README.md
+++ b/examples/transforms/README.md
@@ -1,0 +1,56 @@
+### The Graph Client / Transforms
+
+This examples indicates the use of the transforms property.
+
+The graph client has some built-in transforms:
+
+[Block Tracking](https://github.com/graphprotocol/graph-client#block-tracking)
+[Auto Pagination](https://github.com/graphprotocol/graph-client#automatic-pagination)
+
+GraphQL Mesh also features more transforms which you can read about [here.](https://the-guild.dev/graphql/mesh/docs/transforms/transforms-introduction)
+
+The example here is using the following tools/concepts:
+
+- The Graph Client CLI for generating artifacts
+- GraphQL Mesh prefix transform (https://the-guild.dev/graphql/mesh/docs/transforms/prefix)
+- GraphQL Codegen for type safe SDK
+
+### Getting Started
+
+To run this example, make sure to install the dependencies in the root of the monorepo, and then run this example:
+
+```
+# In the root directory
+$ yarn install
+$ yarn build
+$ cd examples/transforms/
+$ yarn start
+```
+
+### Building
+
+You can also build the client sdk by running: `yarn build`.
+
+### GraphQL Mesh Transforms Usage
+
+To run any transforms on your project from graphql mesh you will need to install the transforms respective dependency. For eg. in this project the prefix transform is used which requires the `@graphql-mesh/transform-prefix` dependency.
+
+Install it by running:
+
+With npm
+
+```
+npm i -D @graphql-mesh/transform-prefix
+```
+
+With yarn
+
+```
+yarn add -D @graphql-mesh/transform-prefix
+```
+
+With pnpm
+
+```
+pnpm add -D @graphql-mesh/transform-prefix
+```

--- a/examples/transforms/package.json
+++ b/examples/transforms/package.json
@@ -3,10 +3,12 @@
   "private": true,
   "version": "0.0.5",
   "scripts": {
+    "build": "graphclient build",
     "start": "graphclient serve-dev"
   },
   "dependencies": {
     "@graphprotocol/client-cli": "2.2.20",
+    "@graphql-mesh/transform-prefix": "0.12.23",
     "graphql": "16.6.0"
   }
 }


### PR DESCRIPTION
- Add a README for the transforms example
- Add the build command to the package.json
- Add the graphql mesh prefix dependency to the example (to maintain consistency, even though it will work without the dependency in the example since the dependency is installed in the auto-pagination example)