### PR TITLE
docs: clarify source selection for composed schemas

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -472,6 +472,8 @@ query myQuery {
 }
 ```
 
+When two sources expose the same root field name, a GraphQL response alias does not select which source should execute that field. For example, `mainnet: pools` and `arbitrum: pools` are still two selections of the same composed `pools` field; the alias only changes the response key. In that case, disambiguate the sources before querying them by using transforms such as `rename` or `prefix`, or by adding explicit schema extension fields that delegate to the intended source.
+
 You can also resolve conflicts, rename parts of the schema, add custom GraphQL fields, and modify the entire execution phase.
 
 For advanced use-cases with composition, please refer to the following resources:


### PR DESCRIPTION
## Summary

Clarifies the client-side composition docs for the case where multiple sources expose the same root field name.

In particular, this notes that GraphQL response aliases such as `mainnet: pools` and `arbitrum: pools` do not select a source; they only change the response key. Users need to disambiguate same-named fields with transforms such as `rename`/`prefix`, or explicit schema extension fields that delegate to a specific source.

## Context

This addresses the confusion described in #1001, where changing source order changes which composed field is resolved.

## Testing

Docs-only change; no runtime tests run.

Refs #1001.
